### PR TITLE
feat: add for-user-id and with-split-rule headers to Create Terminal Payment Session

### DIFF
--- a/api-reference/terminal-api/introduction.mdx
+++ b/api-reference/terminal-api/introduction.mdx
@@ -95,7 +95,7 @@ If you have access to **xenPlatform**, you can include these optional headers on
 
 | Header | Type | Description |
 |--------|------|-------------|
-| `for-user-id` | string | The sub-account user-id to make this transaction for. See [xenPlatform](/api-reference/xenplatform) for more information. |
+| `for-user-id` | string | The sub-account user-id to make this transaction for. See [xenPlatform](https://docs.xendit.co/docs/xenplatform-overview) for more information. |
 | `with-split-rule` | string | The XenPlatform split rule ID that will be applied to this transaction. |
 
 ## Device connectivity

--- a/api-reference/terminal-api/introduction.mdx
+++ b/api-reference/terminal-api/introduction.mdx
@@ -70,6 +70,8 @@ curl -X POST 'https://terminal-dev.xendit.co/v1/terminal/sessions' \
   -u 'your_terminal_api_key:' \
   -H 'Content-Type: application/json' \
   -H 'Idempotency-key: unique-key-123' \
+  -H 'for-user-id: SUB_ACCOUNT_USER_ID' \
+  -H 'with-split-rule: SPLIT_RULE_ID' \
   -d '{
     "session_type": "PAY",
     "mode": "TERMINAL",
@@ -86,6 +88,15 @@ curl -X POST 'https://terminal-dev.xendit.co/v1/terminal/sessions' \
   **Critical**: Always include the colon (`:`) after your API key when encoding
   for Basic Authentication, even though the password is empty.
 </Warning>
+
+## Optional Headers (xenPlatform)
+
+If you have access to **xenPlatform**, you can include these optional headers on the Create Terminal Payment Session request:
+
+| Header | Type | Description |
+|--------|------|-------------|
+| `for-user-id` | string | The sub-account user-id to make this transaction for. See [xenPlatform](/api-reference/xenplatform) for more information. |
+| `with-split-rule` | string | The XenPlatform split rule ID that will be applied to this transaction. |
 
 ## Device connectivity
 

--- a/openapi-spec.yaml
+++ b/openapi-spec.yaml
@@ -24,6 +24,18 @@ paths:
           schema:
             type: string
           description: Idempotency key to ensure the request is not processed multiple times
+        - name: for-user-id
+          in: header
+          required: false
+          schema:
+            type: string
+          description: The sub-account user-id to make this transaction for. This header is only used if you have access to xenPlatform. See xenPlatform for more information.
+        - name: with-split-rule
+          in: header
+          required: false
+          schema:
+            type: string
+          description: The XenPlatform split rule ID that will be applied to this transaction. This header is only used if you have access to xenPlatform.
       requestBody:
         required: true
         content:

--- a/openapi-spec.yaml
+++ b/openapi-spec.yaml
@@ -29,7 +29,7 @@ paths:
           required: false
           schema:
             type: string
-          description: The sub-account user-id to make this transaction for. This header is only used if you have access to xenPlatform. See xenPlatform for more information.
+          description: The sub-account user-id to make this transaction for. This header is only used if you have access to xenPlatform. See [xenPlatform](https://docs.xendit.co/docs/xenplatform-overview) for more information.
         - name: with-split-rule
           in: header
           required: false


### PR DESCRIPTION
## Summary

Add xenPlatform headers to the `createTerminalPaymentSession` endpoint in `openapi-spec.yaml`.

## Changes

- `for-user-id` (string, optional): The sub-account user-id to make this transaction for. This header is only used if you have access to xenPlatform. See xenPlatform for more information.
- `with-split-rule` (string, optional): The XenPlatform split rule ID that will be applied to this transaction. This header is only used if you have access to xenPlatform.