### PR TITLE
Chore/v1.8.0

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -98,19 +98,24 @@
             "pages": [
               "sdk/terminal-sdk/index",
               {
-                "group": "H2H",
+                "group": "SDK",
                 "pages": [
-                  "sdk/h2h/introduction",
-                  "sdk/h2h/android-sdk/index",
-                  "sdk/h2h/ios-sdk/index"
-                ]
-              },
-              {
-                "group": "C2C",
-                "pages": [
-                  "sdk/c2c/introduction",
-                  "sdk/c2c/android-sdk/index",
-                  "sdk/c2c/ios-sdk/index"
+                  {
+                    "group": "Terminal H2H",
+                    "pages": [
+                      "sdk/h2h/introduction",
+                      "sdk/h2h/android-sdk/index",
+                      "sdk/h2h/ios-sdk/index"
+                    ]
+                  },
+                  {
+                    "group": "Terminal C2C",
+                    "pages": [
+                      "sdk/c2c/introduction",
+                      "sdk/c2c/android-sdk/index",
+                      "sdk/c2c/ios-sdk/index"
+                    ]
+                  }
                 ]
               }
             ]

--- a/guides/getting-started/quickstart.mdx
+++ b/guides/getting-started/quickstart.mdx
@@ -246,20 +246,6 @@ import {WizardInit} from '/components/WizardInit.jsx';
           <div className="provider-info">
             <div className="provider-name">
               Cashup
-              <span
-                style={{
-                  marginLeft: '8px',
-                  fontSize: '11px',
-                  textTransform: 'uppercase',
-                  fontWeight: 600,
-                  color: '#92400e',
-                  background: '#fef3c7',
-                  padding: '2px 6px',
-                  borderRadius: '9999px'
-                }}
-              >
-                Coming soon
-              </span>
             </div>
             <div className="provider-desc">Multi-brand payment terminals</div>
           </div>

--- a/sdk/c2c/android-sdk/index.mdx
+++ b/sdk/c2c/android-sdk/index.mdx
@@ -18,10 +18,9 @@ TerminalC2C is a singleton object that provides both synchronous (suspend) and a
 ## Version information
 
 <AccordionGroup>
-  <Accordion title="v1.1.0 — 23-Apr-2026">
+  <Accordion title="v1.1.1 — 23-Apr-2026">
     What's new:
     - Added Cashup provider support for Indonesian terminals
-    - Fixed an issue where the C2C server restarted when launching the app
   </Accordion>
   <Accordion title="v1.0.0 — 19-Feb-2026">
     What's new:

--- a/sdk/c2c/android-sdk/index.mdx
+++ b/sdk/c2c/android-sdk/index.mdx
@@ -218,7 +218,7 @@ For Share Commerce (SHC) and Cashup terminals, make sure the Gateway app is inst
     </Info>
   </Tab>
   
-  <Tab title="Cashup Indonesia (Coming Soon)">
+  <Tab title="Cashup Indonesia">
     ```kotlin
     // Add Cashup provider for Indonesian terminals
     TerminalC2C.addProvider(TerminalCashup)
@@ -415,7 +415,7 @@ BRI terminals support both physical card payments and digital payment methods po
 
 </Tab>
 
-<Tab title="Cashup Terminals (Coming Soon)">
+<Tab title="Cashup Terminals">
 
 When using `co.xendit.terminal:id-cashup-android` dependency:
 

--- a/sdk/c2c/android-sdk/index.mdx
+++ b/sdk/c2c/android-sdk/index.mdx
@@ -18,7 +18,7 @@ TerminalC2C is a singleton object that provides both synchronous (suspend) and a
 ## Version information
 
 <AccordionGroup>
-  <Accordion title="v1.1.0 — 16-Apr-2026">
+  <Accordion title="v1.1.0 — 23-Apr-2026">
     What's new:
     - Added Cashup provider support for Indonesian terminals
     - Fixed an issue where the C2C server restarted when launching the app

--- a/sdk/c2c/android-sdk/index.mdx
+++ b/sdk/c2c/android-sdk/index.mdx
@@ -18,9 +18,13 @@ TerminalC2C is a singleton object that provides both synchronous (suspend) and a
 ## Version information
 
 <AccordionGroup>
-  <Accordion title="v1.0.0 — 19-Feb-2026">
+  <Accordion title="v1.1.0 — 16-Apr-2026">
     What's new:
     - Added Cashup provider support for Indonesian terminals
+    - Fixed an issue where the C2C server restarted when launching the app
+  </Accordion>
+  <Accordion title="v1.0.0 — 19-Feb-2026">
+    What's new:
     - Added SHC provider support for Malaysian terminals
     - Added multiple-provider support enabling apps to handle different terminal types simultaneously
     - Enhanced TerminalDevice configuration with provider-specific methods
@@ -32,36 +36,24 @@ TerminalC2C is a singleton object that provides both synchronous (suspend) and a
 The SDK follows semantic versioning. Breaking changes will bump the major version number.
 </Note>
 
-import AndroidDownload from '/snippets/android-download.mdx';
-
-<AndroidDownload />
-
 ## Installation
 
 Follow these steps to add the Terminal C2C Android SDK to your project.
 
 <Steps>
-<Step title="Extract the SDK">
-  Extract the provided SDK zip file so that a `repository` directory is available in your project root.
-  
-  <Check>
-  Verify that the `repository` folder contains the necessary Maven artifacts for the SDK.
-  </Check>
-</Step>
-
 <Step title="Configure Gradle settings">
-  Add the repository to your Gradle configuration. Choose one of the following approaches:
+  Add `mavenCentral()` to your Gradle configuration so Gradle can resolve the SDK artifacts.
   
   <Tabs>
   <Tab title="Modern Approach (Recommended)">
-    Add the repository to your Gradle settings file:
+    Add Maven Central to your Gradle settings file:
     
     <CodeGroup>
     ```kotlin settings.gradle(.kts)
     dependencyResolutionManagement {
       repositories {
         // ... other repositories
-        maven("./repository")
+        mavenCentral()
       }
     }
     ```
@@ -70,7 +62,7 @@ Follow these steps to add the Terminal C2C Android SDK to your project.
     dependencyResolutionManagement {
       repositories {
         // ... other repositories
-        maven { url './repository' }
+        mavenCentral()
       }
     }
     ```
@@ -78,14 +70,14 @@ Follow these steps to add the Terminal C2C Android SDK to your project.
   </Tab>
   
   <Tab title="Old Android Project">
-    Add the repository to your root build.gradle file:
+    Add Maven Central to your root build.gradle file:
     
     <CodeGroup>
     ```kotlin build.gradle.kts (root)
     allprojects {
       repositories {
         // ... other repositories
-        maven("../repository")
+        mavenCentral()
       }
     }
     ```
@@ -94,13 +86,17 @@ Follow these steps to add the Terminal C2C Android SDK to your project.
     allprojects {
       repositories {
         // ... other repositories
-        maven { url '../repository' }
+        mavenCentral()
       }
     }
     ```
     </CodeGroup>
   </Tab>
   </Tabs>
+
+  <Check>
+  Verify `mavenCentral()` is available in the repository list used by your app module.
+  </Check>
 </Step>
 
 <Step title="Add dependencies">

--- a/sdk/c2c/ios-sdk/index.mdx
+++ b/sdk/c2c/ios-sdk/index.mdx
@@ -109,7 +109,7 @@ For Share Commerce (SHC) and Cashup terminals, make sure the Gateway app is inst
   </Info>
 </Tab>
 
-<Tab title="Cashup Indonesia (Coming Soon)">
+<Tab title="Cashup Indonesia">
   ```swift
   // Add Cashup provider for Indonesian terminals
   TerminalC2C.shared.addProvider(provider: TerminalCashup.shared)
@@ -285,7 +285,7 @@ BRI terminals support both physical card payments and digital payment methods po
 
 </Tab>
 
-<Tab title="Cashup Terminals (Coming Soon)">
+<Tab title="Cashup Terminals">
 
 When using Cashup terminal configuration:
 

--- a/sdk/c2c/ios-sdk/index.mdx
+++ b/sdk/c2c/ios-sdk/index.mdx
@@ -18,9 +18,13 @@ This SDK uses a singleton pattern with the `TerminalC2C` object to communicate w
 ## Version information
 
 <AccordionGroup>
-  <Accordion title="v1.0.0 — 19-Feb-2026">
+  <Accordion title="v1.1.0 — 16-Apr-2026">
     What's new:
     - Added Cashup provider support for Indonesian terminals
+    - Fixed an issue where the C2C server restarted when launching the app
+  </Accordion>
+  <Accordion title="v1.0.0 — 19-Feb-2026">
+    What's new:
     - Added SHC provider support for Malaysian terminals
     - Added multiple-provider support enabling apps to handle different terminal types simultaneously
     - Enhanced TerminalDevice configuration with provider-specific methods
@@ -31,27 +35,6 @@ This SDK uses a singleton pattern with the `TerminalC2C` object to communicate w
 <Note>
 The SDK follows semantic versioning. Breaking changes will bump the major version number.
 </Note>
-
-## Download
-
-Download the Terminal C2C iOS SDK:
-
-<CardGroup cols={1}>
-<Card title="iOS SDK (v1.0.0)" icon="apple">
-  Download the complete iOS SDK package including TerminalC2C.xcframework and documentation
-
-  ```
-  SHA256: 2ca43d04afbfb1c7237f41e07b44de9dcc9fb80386e995dc287a41938fa618d9
-  ```
-
-  <a
-    href="https://xnd-secops.s3.ap-southeast-1.amazonaws.com/inpersonpayments/TerminalSDK+C2C+iOS-1.0.0.zip"
-    className="inline-flex items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
-  >
-    Download for iOS
-  </a>
-</Card>
-</CardGroup>
 
 import IOSInstallation from '/snippets/ios-installation.mdx';
 

--- a/sdk/c2c/ios-sdk/index.mdx
+++ b/sdk/c2c/ios-sdk/index.mdx
@@ -18,7 +18,7 @@ This SDK uses a singleton pattern with the `TerminalC2C` object to communicate w
 ## Version information
 
 <AccordionGroup>
-  <Accordion title="v1.1.0 — 16-Apr-2026">
+  <Accordion title="v1.1.0 — 23-Apr-2026">
     What's new:
     - Added Cashup provider support for Indonesian terminals
     - Fixed an issue where the C2C server restarted when launching the app

--- a/sdk/c2c/ios-sdk/index.mdx
+++ b/sdk/c2c/ios-sdk/index.mdx
@@ -18,10 +18,9 @@ This SDK uses a singleton pattern with the `TerminalC2C` object to communicate w
 ## Version information
 
 <AccordionGroup>
-  <Accordion title="v1.1.0 — 23-Apr-2026">
+  <Accordion title="v1.1.1 — 23-Apr-2026">
     What's new:
     - Added Cashup provider support for Indonesian terminals
-    - Fixed an issue where the C2C server restarted when launching the app
   </Accordion>
   <Accordion title="v1.0.0 — 19-Feb-2026">
     What's new:

--- a/sdk/gateway/app-configuration.mdx
+++ b/sdk/gateway/app-configuration.mdx
@@ -101,7 +101,7 @@ Choose your operating system to download the Terminal Gateway app installer:
   Download the macOS installer (v1.8.0).
 
   ```
-  SHA256:
+  SHA256:941cb7b190f6d218d40aa8bd3b927013f7d1a3f43b4adcdda9725652dc7d30d9
   ```
 
   <a
@@ -116,7 +116,7 @@ Choose your operating system to download the Terminal Gateway app installer:
   Download the Windows installer (v1.8.0).
 
   ```
-  SHA256:
+  SHA256:111d0aaf98b48c97ce6f7a111e657bee69841f7c93426504dd9f9f8ae76366c9
   ```
 
   <a

--- a/sdk/gateway/app-configuration.mdx
+++ b/sdk/gateway/app-configuration.mdx
@@ -16,7 +16,7 @@ The Terminal Gateway app helps developers integrate their application with Xendi
 ## Version information
 
 <AccordionGroup>
-  <Accordion title="v1.8.0 — 16-Apr-2026">
+  <Accordion title="v1.8.0 — 23-Apr-2026">
     What's new:
     - Added Cashup provider support for Indonesian terminals
     - Fixed an issue where the C2C server restarted when launching the app
@@ -131,7 +131,7 @@ Choose your operating system to download the Terminal Gateway app installer:
   Download the Android APK (v1.8.0).
 
   ```
-  SHA256:
+  SHA256:2ec5be58a6d8b4fe335c37d99e9b21364b2d927d3d22c524f4ba27f7d47d1380
   ```
 
   <a

--- a/sdk/gateway/app-configuration.mdx
+++ b/sdk/gateway/app-configuration.mdx
@@ -16,6 +16,11 @@ The Terminal Gateway app helps developers integrate their application with Xendi
 ## Version information
 
 <AccordionGroup>
+  <Accordion title="v1.8.0 — 16-Apr-2026">
+    What's new:
+    - Added Cashup provider support for Indonesian terminals
+    - Fixed an issue where the C2C server restarted when launching the app
+  </Accordion>
   <Accordion title="v1.7.1 — 12-Mar-2026">
     Bug fixes and improvements:
     - Fixed text field not editable in configuration and input screens
@@ -26,55 +31,59 @@ The Terminal Gateway app helps developers integrate their application with Xendi
     - Added Cashup provider support for Indonesian terminals
     - Made the client-to-client port static at 8189 for consistent POS connectivity
   </Accordion>
-  <Accordion title="v1.6.0 — 5-Dec-2025">
-    What's new:
-    - Fixed the NTT payment method value to ensure correct provider mapping
-    - Updated the BRI payment flow to validate transaction data before performing terminal actions
-    - Added timeout configuration for card and QR transactions to control operation windows
-    - Added support to handle retry requests via <a href="/api-reference/payments-terminal-api/retry-terminal-payment-session">`/v1/terminal/sessions/{id}/retry`</a> endpoint
-  </Accordion>
-  <Accordion title="v1.5.0 — 20-Nov-2025">
-    What's new:
-    - Added support for multiple concurrent device connections so you can orchestrate simultaneous sessions across different terminals
-    - [BRI] Fixed status value handling in void and cancel API responses for improved transaction status accuracy
-    - Enhanced the Android app lifecycle with a splash screen, notification handling, and provider app launcher support for a smoother user experience
-    - Fixed client-to-client API calls and the associated request queue to prevent stalled commands
-  </Accordion>
-  <Accordion title="v1.4.0 — 30-Oct-2025">
-    New features and improvements:
-    - Added transaction timeout configuration with UI support and validation
-    - Introduced command ID handling for settlement operations
-    - Enhanced retry logic with configurable attempt counts
-    - Improved error handling and logging throughout the gateway service
-    - In-app version update
-    - Renamed to Gateway with updated icons
-  </Accordion>
-  <Accordion title="v1.3.2 — 7-Oct-2025">
-    Bug fixes and improvements:
-    - Fix data mapping for terminal responses
-    - Hide device's restart button when connection mode is C2C
-    - Fix "restart service" button behavior on C2C mode
-    - [BRI] Enhanced status verification after transaction timeout for improved reliability
-  </Accordion>
+  <Accordion title="View all versions">
+    <AccordionGroup>
+      <Accordion title="v1.6.0 — 5-Dec-2025">
+        What's new:
+        - Fixed the NTT payment method value to ensure correct provider mapping
+        - Updated the BRI payment flow to validate transaction data before performing terminal actions
+        - Added timeout configuration for card and QR transactions to control operation windows
+        - Added support to handle retry requests via <a href="/api-reference/payments-terminal-api/retry-terminal-payment-session">`/v1/terminal/sessions/{id}/retry`</a> endpoint
+      </Accordion>
+      <Accordion title="v1.5.0 — 20-Nov-2025">
+        What's new:
+        - Added support for multiple concurrent device connections so you can orchestrate simultaneous sessions across different terminals
+        - [BRI] Fixed status value handling in void and cancel API responses for improved transaction status accuracy
+        - Enhanced the Android app lifecycle with a splash screen, notification handling, and provider app launcher support for a smoother user experience
+        - Fixed client-to-client API calls and the associated request queue to prevent stalled commands
+      </Accordion>
+      <Accordion title="v1.4.0 — 30-Oct-2025">
+        New features and improvements:
+        - Added transaction timeout configuration with UI support and validation
+        - Introduced command ID handling for settlement operations
+        - Enhanced retry logic with configurable attempt counts
+        - Improved error handling and logging throughout the gateway service
+        - In-app version update
+        - Renamed to Gateway with updated icons
+      </Accordion>
+      <Accordion title="v1.3.2 — 7-Oct-2025">
+        Bug fixes and improvements:
+        - Fix data mapping for terminal responses
+        - Hide device's restart button when connection mode is C2C
+        - Fix "restart service" button behavior on C2C mode
+        - [BRI] Enhanced status verification after transaction timeout for improved reliability
+      </Accordion>
 
-  <Accordion title="v1.3.1 — 26-Sep-2025">
-    Bug fixes and improvements:
-    - Fix UI issue
-    - Fix date time parser issue
-    - Fix test flag toggle not showing correct state on app open
-  </Accordion>
+      <Accordion title="v1.3.1 — 26-Sep-2025">
+        Bug fixes and improvements:
+        - Fix UI issue
+        - Fix date time parser issue
+        - Fix test flag toggle not showing correct state on app open
+      </Accordion>
 
-  <Accordion title="v1.3.0 — 11-Sep-2025">
-    Update UI/UX for improved user experience and interface design.
-  </Accordion>
+      <Accordion title="v1.3.0 — 11-Sep-2025">
+        Update UI/UX for improved user experience and interface design.
+      </Accordion>
 
-  <Accordion title="v1.2.1 — 27-Aug-2025">
-    Remove timezone pinning for the BRI terminal. Fix an issue where the app
-    executes the same command after a transaction completes.
-  </Accordion>
+      <Accordion title="v1.2.1 — 27-Aug-2025">
+        Remove timezone pinning for the BRI terminal. Fix an issue where the app
+        executes the same command after a transaction completes.
+      </Accordion>
 
-  <Accordion title="v1.2.0 — 7-June-2025">
-    Terminal H2H is the companion SDK to In-Person Payments Terminal API.
+      <Accordion title="v1.2.0 — 7-June-2025">
+        Terminal H2H is the companion SDK to In-Person Payments Terminal API.
+      </Accordion>
+    </AccordionGroup>
   </Accordion>
 </AccordionGroup>
 
@@ -89,14 +98,14 @@ Choose your operating system to download the Terminal Gateway app installer:
 
 <CardGroup cols={2}>
 <Card title="macOS (.dmg)" icon="apple">
-  Download the macOS installer (v1.7.1).
+  Download the macOS installer (v1.8.0).
 
   ```
-  SHA256: 2e8edf7df34d93c3c77727deba748415d330a64e50bd95d2e486aba09bd49df5
+  SHA256:
   ```
 
   <a
-    href="https://xnd-secops.s3.ap-southeast-1.amazonaws.com/inpersonpayments/Xendit+Terminal+Gateway-1.7.1.dmg"
+    href="https://xnd-secops.s3.ap-southeast-1.amazonaws.com/inpersonpayments/Xendit+Terminal+Gateway-1.8.0.dmg"
     className="inline-flex items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
   >
     Download for macOS
@@ -104,14 +113,14 @@ Choose your operating system to download the Terminal Gateway app installer:
 </Card>
 
 <Card title="Windows (.msi)" icon="windows">
-  Download the Windows installer (v1.7.1).
+  Download the Windows installer (v1.8.0).
 
   ```
-  SHA256: 3ebb37174bea11d255fb9d19b4118943952cbc1a0666ab355d3729d01b803210
+  SHA256:
   ```
 
   <a
-    href="https://xnd-secops.s3.ap-southeast-1.amazonaws.com/inpersonpayments/Xendit+Terminal+Gateway-1.7.1.msi"
+    href="https://xnd-secops.s3.ap-southeast-1.amazonaws.com/inpersonpayments/Xendit+Terminal+Gateway-1.8.0.msi"
     className="inline-flex items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
   >
     Download for Windows
@@ -119,14 +128,14 @@ Choose your operating system to download the Terminal Gateway app installer:
 </Card>
 
 <Card title="Android (.apk)" icon="android">
-  Download the Android APK (v1.7.1).
+  Download the Android APK (v1.8.0).
 
   ```
-  SHA256: 0db9b918bc0636c2f45b270ae600daf4cfc14d1dd7afd66a461d5fea3161190d
+  SHA256:
   ```
 
   <a
-    href="https://xnd-secops.s3.ap-southeast-1.amazonaws.com/inpersonpayments/Xendit+Terminal+Gateway-1.7.1.apk"
+    href="https://xnd-secops.s3.ap-southeast-1.amazonaws.com/inpersonpayments/Xendit+Terminal+Gateway-1.8.0.apk"
     className="inline-flex items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
   >
     Download for Android

--- a/sdk/h2h/android-sdk/index.mdx
+++ b/sdk/h2h/android-sdk/index.mdx
@@ -14,10 +14,9 @@ This SDK works alongside the Terminal API to provide complete in-person payment 
 ## Version information
 
 <AccordionGroup>
-  <Accordion title="v1.1.0 — 23-Apr-2026">
+  <Accordion title="v1.1.1 — 23-Apr-2026">
     What's new:
     - Added Cashup provider support for Indonesian terminals
-    - Fixed an issue where the H2H server restarted when launching the app
   </Accordion>
   <Accordion title="v1.0.0 — 19-Feb-2026">
     What's new:

--- a/sdk/h2h/android-sdk/index.mdx
+++ b/sdk/h2h/android-sdk/index.mdx
@@ -246,6 +246,17 @@ NTT provider supports multi-function terminals with card payments and QR code tr
 </Info>
 </Tab>
 
+<Tab title="Cashup (Indonesia)">
+```kotlin
+// Cashup terminals use the Gateway app flow.
+// No TerminalH2H.addProvider(...) call is required.
+```
+
+<Info>
+Cashup terminals run terminal logic through the Gateway app on the device. Ensure the Gateway app is installed and your terminal is registered before processing payments.
+</Info>
+</Tab>
+
 <Tab title="Multiple Providers">
 ```kotlin
 // Add multiple providers for supporting different terminal types

--- a/sdk/h2h/android-sdk/index.mdx
+++ b/sdk/h2h/android-sdk/index.mdx
@@ -14,6 +14,11 @@ This SDK works alongside the Terminal API to provide complete in-person payment 
 ## Version information
 
 <AccordionGroup>
+  <Accordion title="v1.1.0 — 23-Apr-2026">
+    What's new:
+    - Added Cashup provider support for Indonesian terminals
+    - Fixed an issue where the H2H server restarted when launching the app
+  </Accordion>
   <Accordion title="v1.0.0 — 19-Feb-2026">
     What's new:
     - Renamed class name `TerminalGateway` to `TerminalH2H` for better consistency

--- a/sdk/h2h/android-sdk/index.mdx
+++ b/sdk/h2h/android-sdk/index.mdx
@@ -34,20 +34,24 @@ This SDK works alongside the Terminal API to provide complete in-person payment 
     - Added support for multiple concurrent device connections, enabling simultaneous transactions across different terminals
     - [BRI] Fixed status value handling in void and cancel API responses for improved transaction status accuracy
   </Accordion>
-  <Accordion title="v0.5.0 — 30-Oct-2025">
-    What's new:
-    - Introduced command ID handling for settlement operations
-    - Enhanced retry logic with configurable attempt counts
-    - Improved error handling and logging throughout the gateway service
-  </Accordion>
-  <Accordion title="v0.4.1 — 7-Oct-2025">
-    Bug fixes and improvements:
-    - Fix data mapping for terminal responses
-    - [BRI] Enhanced status verification after transaction timeout for improved reliability
-  </Accordion>
+  <Accordion title="View all versions">
+    <AccordionGroup>
+      <Accordion title="v0.5.0 — 30-Oct-2025">
+        What's new:
+        - Introduced command ID handling for settlement operations
+        - Enhanced retry logic with configurable attempt counts
+        - Improved error handling and logging throughout the gateway service
+      </Accordion>
+      <Accordion title="v0.4.1 — 7-Oct-2025">
+        Bug fixes and improvements:
+        - Fix data mapping for terminal responses
+        - [BRI] Enhanced status verification after transaction timeout for improved reliability
+      </Accordion>
 
-  <Accordion title="v0.4.0 — 13-May-2025">
-    XenTerminal is the companion SDK to In-Person Payment Sessions API. This version provides core functionality for connecting to payment terminals and processing transactions.
+      <Accordion title="v0.4.0 — 13-May-2025">
+        XenTerminal is the companion SDK to In-Person Payment Sessions API. This version provides core functionality for connecting to payment terminals and processing transactions.
+      </Accordion>
+    </AccordionGroup>
   </Accordion>
 </AccordionGroup>
 

--- a/sdk/h2h/android-sdk/index.mdx
+++ b/sdk/h2h/android-sdk/index.mdx
@@ -55,36 +55,24 @@ This SDK works alongside the Terminal API to provide complete in-person payment 
 The SDK follows semantic versioning. Breaking changes will bump the major version number.
 </Note>
 
-import AndroidDownload from '/snippets/android-download.mdx';
-
-<AndroidDownload />
-
 ## Installation
 
 Follow these steps to add the Terminal H2H Android SDK to your project.
 
 <Steps>
-<Step title="Extract the SDK">
-  Extract the provided SDK zip file so that a `repository` directory is available in your project root.
-  
-  <Check>
-  Verify that the `repository` folder contains the necessary Maven artifacts for the SDK.
-  </Check>
-</Step>
-
 <Step title="Configure Gradle settings">
-  Add the repository to your Gradle configuration. Choose one of the following approaches:
+  Add `mavenCentral()` to your Gradle configuration so Gradle can resolve the SDK artifacts.
   
   <Tabs>
   <Tab title="Modern Approach (Recommended)">
-    Add the repository to your Gradle settings file:
+    Add Maven Central to your Gradle settings file:
     
     <CodeGroup>
     ```kotlin settings.gradle(.kts)
     dependencyResolutionManagement {
       repositories {
         // ... other repositories
-        maven("./repository")
+        mavenCentral()
       }
     }
     ```
@@ -93,7 +81,7 @@ Follow these steps to add the Terminal H2H Android SDK to your project.
     dependencyResolutionManagement {
       repositories {
         // ... other repositories
-        maven { url './repository' }
+        mavenCentral()
       }
     }
     ```
@@ -101,14 +89,14 @@ Follow these steps to add the Terminal H2H Android SDK to your project.
   </Tab>
   
   <Tab title="Old Android Project">
-    Add the repository to your root build.gradle file:
+    Add Maven Central to your root build.gradle file:
     
     <CodeGroup>
     ```kotlin build.gradle.kts (root)
     allprojects {
       repositories {
         // ... other repositories
-        maven("../repository")
+        mavenCentral()
       }
     }
     ```
@@ -117,13 +105,17 @@ Follow these steps to add the Terminal H2H Android SDK to your project.
     allprojects {
       repositories {
         // ... other repositories
-        maven { url '../repository' }
+        mavenCentral()
       }
     }
     ```
     </CodeGroup>
   </Tab>
   </Tabs>
+
+  <Check>
+  Verify `mavenCentral()` is available in the repository list used by your app module.
+  </Check>
 </Step>
 
 <Step title="Add dependencies">

--- a/sdk/h2h/ios-sdk/index.mdx
+++ b/sdk/h2h/ios-sdk/index.mdx
@@ -14,7 +14,7 @@ This SDK works alongside the Terminal API to provide a complete in-person paymen
 ## Version information
 
 <AccordionGroup>
-  <Accordion title="v1.1.0 — 16-Apr-2026">
+  <Accordion title="v1.1.0 — 23-Apr-2026">
     What's new:
     - Added Cashup provider support for Indonesian terminals
     - Fixed an issue where the H2H server restarted when launching the app

--- a/sdk/h2h/ios-sdk/index.mdx
+++ b/sdk/h2h/ios-sdk/index.mdx
@@ -132,6 +132,17 @@ NTT provider supports multi-function terminals with card payments and QR code tr
 </Info>
 </Tab>
 
+<Tab title="Cashup (Indonesia)">
+```swift
+// Cashup terminals use the Gateway app flow.
+// No TerminalH2H.shared.addProvider(...) call is required.
+```
+
+<Info>
+Cashup terminals run terminal logic through the Gateway app on the device. Ensure the Gateway app is installed and your terminal is registered before processing payments.
+</Info>
+</Tab>
+
 <Tab title="Multiple Providers">
 ```swift
 // Add multiple providers for supporting different terminal types

--- a/sdk/h2h/ios-sdk/index.mdx
+++ b/sdk/h2h/ios-sdk/index.mdx
@@ -14,10 +14,9 @@ This SDK works alongside the Terminal API to provide a complete in-person paymen
 ## Version information
 
 <AccordionGroup>
-  <Accordion title="v1.1.0 — 23-Apr-2026">
+  <Accordion title="v1.1.1 — 23-Apr-2026">
     What's new:
     - Added Cashup provider support for Indonesian terminals
-    - Fixed an issue where the H2H server restarted when launching the app
   </Accordion>
   <Accordion title="v1.0.0 — 19-Feb-2026">
     What's new:

--- a/sdk/h2h/ios-sdk/index.mdx
+++ b/sdk/h2h/ios-sdk/index.mdx
@@ -14,6 +14,11 @@ This SDK works alongside the Terminal API to provide a complete in-person paymen
 ## Version information
 
 <AccordionGroup>
+  <Accordion title="v1.1.0 — 16-Apr-2026">
+    What's new:
+    - Added Cashup provider support for Indonesian terminals
+    - Fixed an issue where the H2H server restarted when launching the app
+  </Accordion>
   <Accordion title="v1.0.0 — 19-Feb-2026">
     What's new:
     - Renamed class name `TerminalGateway` to `TerminalH2H` for better consistency
@@ -29,52 +34,35 @@ This SDK works alongside the Terminal API to provide a complete in-person paymen
     - Added timeout configuration for card and QR transactions to auto-cancel and retry stalled requests
     - Added support to handle retry requests via <a href="/api-reference/payments-terminal-api/retry-terminal-payment-session">`/v1/terminal/sessions/{id}/retry`</a> endpoint
   </Accordion>
-  <Accordion title="v0.6.0 — 20-Nov-2025">
-    What's new:
-    - Added support for multiple concurrent device connections, enabling simultaneous transactions across different terminals
-    - [BRI] Fixed status value handling in void and cancel API responses for improved transaction status accuracy
-  </Accordion>
-  <Accordion title="v0.5.0 — 30-Oct-2025">
-    What's new:
-    - Introduced command ID handling for settlement operations
-    - Enhanced retry logic with configurable attempt counts
-    - Improved error handling and logging throughout the gateway service
-  </Accordion>
-  <Accordion title="v0.4.1 — 7-Oct-2025">
-    Bug fixes and improvements:
-    - Fix data mapping for terminal responses
-    - [BRI] Enhanced status verification after transaction timeout for improved reliability
-  </Accordion>
+  <Accordion title="View all versions">
+    <AccordionGroup>
+      <Accordion title="v0.6.0 — 20-Nov-2025">
+        What's new:
+        - Added support for multiple concurrent device connections, enabling simultaneous transactions across different terminals
+        - [BRI] Fixed status value handling in void and cancel API responses for improved transaction status accuracy
+      </Accordion>
+      <Accordion title="v0.5.0 — 30-Oct-2025">
+        What's new:
+        - Introduced command ID handling for settlement operations
+        - Enhanced retry logic with configurable attempt counts
+        - Improved error handling and logging throughout the gateway service
+      </Accordion>
+      <Accordion title="v0.4.1 — 7-Oct-2025">
+        Bug fixes and improvements:
+        - Fix data mapping for terminal responses
+        - [BRI] Enhanced status verification after transaction timeout for improved reliability
+      </Accordion>
 
-  <Accordion title="v0.4.0 — 13-May-2025">
-    XenTerminal is the companion SDK to In-Person Payment Sessions API. This version provides core functionality for connecting to payment terminals and processing transactions.
+      <Accordion title="v0.4.0 — 13-May-2025">
+        XenTerminal is the companion SDK to In-Person Payment Sessions API. This version provides core functionality for connecting to payment terminals and processing transactions.
+      </Accordion>
+    </AccordionGroup>
   </Accordion>
 </AccordionGroup>
 
 <Note>
 The SDK follows semantic versioning. Breaking changes will bump the major version number.
 </Note>
-
-## Download
-
-Download the Terminal H2H iOS SDK:
-
-<CardGroup cols={1}>
-<Card title="iOS SDK (v1.0.0)" icon="apple">
-  Download the complete iOS SDK package including TerminalH2H.xcframework and documentation
-
-  ```
-  SHA256: 61a97854a65501d0c1c14dc7fe94005cd6c0d72b35ee6157ec5a65c74b52e8b7
-  ```
-
-  <a
-    href="https://xnd-secops.s3.ap-southeast-1.amazonaws.com/inpersonpayments/TerminalSDK+H2H+iOS-1.0.0.zip"
-    className="inline-flex items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
-  >
-    Download for iOS
-  </a>
-</Card>
-</CardGroup>
 
 import IOSInstallation from '/snippets/ios-installation.mdx';
 

--- a/snippets/ios-installation.mdx
+++ b/snippets/ios-installation.mdx
@@ -1,47 +1,35 @@
 ## Installation
 
-Install the Terminal SDK by adding it as a framework in Xcode:
+Install the Terminal SDK using Swift Package Manager (SPM) in Xcode:
 
 <Steps>
-<Step title="Extract framework">
-  Extract the framework zip file in your project directory.
-  
-  <Frame>
-  <img src="/images/ios/extract-zip.png" alt="Extracting framework zip file in Finder" />
-  </Frame>
-</Step>
-
-<Step title="Add framework to project">
-  In Xcode, open your project and choose **File → Add Package Dependencies…** to start the package flow.
+<Step title="Open package dependencies in Xcode">
+  In Xcode, open your project and choose **File → Add Package Dependencies...**.
   
   <Frame>
   <img src="/images/ios/add-package.png" alt="Opening the Add Package Dependencies menu in Xcode" />
   </Frame>
 </Step>
 
-<Step title="Import framework">
-  1. Click **Add Local…** when prompted.
-  2. Browse to the extracted framework zip/location and select the package manifest.
-  3. Ensure the correct target is selected, then click **Add Package** to finish.
-  
-  <Frame>
-  <img src="/images/ios/add-local.png" alt="Choosing Add Local during the package dependency flow" />
-  </Frame>
-  
-  <Frame>
-  <img src="/images/ios/locate-files.png" alt="Locating the extracted framework files" />
-  </Frame>
-  
-  <Frame>
-  <img src="/images/ios/add-to-target.png" alt="Selecting the correct target before adding the package" />
-  </Frame>
+<Step title="Add Xendit package URL">
+  Enter this repository URL in the package search field:
+
+  ```text
+  https://github.com/xendit/xendit-terminal-ios
+  ```
+
+  Then click **Add Package**.
+</Step>
+
+<Step title="Select version and target">
+  Choose your dependency rule (recommended: **Up to Next Major Version**) and make sure your app target is selected before confirming.
 </Step>
 
 <Step title="Configure build settings">
-  Go to "Build Settings" and make the following changes:
+  Go to **Build Settings** and make the following changes:
   
-  - Search for "ENABLE_USER_SCRIPT_SANDBOXING" and set it to "NO"
-  - Search for "Other Linker Flags" and add "-lsqlite3"
+  - Search for `ENABLE_USER_SCRIPT_SANDBOXING` and set it to `NO`
+  - Search for `Other Linker Flags` and add `-lsqlite3`
   
   <Frame>
   <img src="/images/ios/enable-sandbox-no.png" alt="Setting ENABLE_USER_SCRIPT_SANDBOXING to NO in Xcode Build Settings" />


### PR DESCRIPTION
This pull request updates the documentation and SDK guides for the Terminal H2H, C2C, and Gateway products, primarily to announce and document support for the Cashup provider for Indonesian terminals. It also simplifies Android SDK installation instructions by moving to Maven Central, updates version histories, and refreshes download links for the Gateway app.

**SDK and Provider Support Updates**

* Added documentation and changelog entries for Cashup provider support for Indonesian terminals in Terminal H2H and C2C SDKs (Android and iOS), including new version entries (`v1.1.1` for SDKs, `v1.8.0` for Gateway app). [[1]](diffhunk://#diff-9eaead37c639fc1d4eb084318ebe5895d40696ee04ed245eee68038390002892R17-R20) [[2]](diffhunk://#diff-4c437b55ab2e15178f2a651bf4b5128c3ecdf0649f07f6081183988e844be942R17-R20) [[3]](diffhunk://#diff-d6e8b144c02e3046e4690fc1d7a7f3b9d71b7bd75ba232812339bb026703289bL21-R26) [[4]](diffhunk://#diff-1da94036bb1e30feef58b5743b6843a704bb59eea0c232b53c78c08db4486c8cL21-R26) [[5]](diffhunk://#diff-53a76e881dbc2f515c7d4adf422932ccf8a1c13576a9c17f5e37ae262c247165R19-R23)
* Updated provider tabs and instructions to remove "Coming Soon" labels for Cashup, reflecting that support is now available. [[1]](diffhunk://#diff-d6e8b144c02e3046e4690fc1d7a7f3b9d71b7bd75ba232812339bb026703289bL225-R220) [[2]](diffhunk://#diff-d6e8b144c02e3046e4690fc1d7a7f3b9d71b7bd75ba232812339bb026703289bL422-R417) [[3]](diffhunk://#diff-1da94036bb1e30feef58b5743b6843a704bb59eea0c232b53c78c08db4486c8cL129-R111) [[4]](diffhunk://#diff-1da94036bb1e30feef58b5743b6843a704bb59eea0c232b53c78c08db4486c8cL305-R287) [[5]](diffhunk://#diff-b03f4f6525d4f062429be2c5c10ecef4530e430f218a0c98fc4e128d46215737L249-L262)

**SDK Installation and Download Instructions**

* Simplified Android SDK installation steps for both H2H and C2C: removed manual repository extraction/download steps and switched to using `mavenCentral()` for dependency resolution. [[1]](diffhunk://#diff-d6e8b144c02e3046e4690fc1d7a7f3b9d71b7bd75ba232812339bb026703289bL35-R55) [[2]](diffhunk://#diff-d6e8b144c02e3046e4690fc1d7a7f3b9d71b7bd75ba232812339bb026703289bL73-R79) [[3]](diffhunk://#diff-d6e8b144c02e3046e4690fc1d7a7f3b9d71b7bd75ba232812339bb026703289bL97-R98) [[4]](diffhunk://#diff-9eaead37c639fc1d4eb084318ebe5895d40696ee04ed245eee68038390002892R59-R83) [[5]](diffhunk://#diff-9eaead37c639fc1d4eb084318ebe5895d40696ee04ed245eee68038390002892L96-R107) [[6]](diffhunk://#diff-9eaead37c639fc1d4eb084318ebe5895d40696ee04ed245eee68038390002892L120-R126)
* Removed obsolete download cards/sections for SDK packages that are now distributed via Maven Central. [[1]](diffhunk://#diff-1da94036bb1e30feef58b5743b6843a704bb59eea0c232b53c78c08db4486c8cL35-L55) [[2]](diffhunk://#diff-9eaead37c639fc1d4eb084318ebe5895d40696ee04ed245eee68038390002892R59-R83)

**Gateway App Documentation and Downloads**

* Updated Gateway app documentation with new version (`v1.8.0`), changelog, and download links for macOS, Windows, and Android, including new SHA256 hashes. [[1]](diffhunk://#diff-53a76e881dbc2f515c7d4adf422932ccf8a1c13576a9c17f5e37ae262c247165R34-R35) [[2]](diffhunk://#diff-53a76e881dbc2f515c7d4adf422932ccf8a1c13576a9c17f5e37ae262c247165R87-R88) [[3]](diffhunk://#diff-53a76e881dbc2f515c7d4adf422932ccf8a1c13576a9c17f5e37ae262c247165L92-R138)

**Documentation Structure**

* Updated `docs.json` to reorganize SDK documentation navigation, grouping H2H and C2C under "Terminal H2H" and "Terminal C2C" for improved clarity. [[1]](diffhunk://#diff-b7b4169fa5b2e02aa17d40553a73c5d9520086753c501eeb926c63b162bb6d9eL101-R112) [[2]](diffhunk://#diff-b7b4169fa5b2e02aa17d40553a73c5d9520086753c501eeb926c63b162bb6d9eR123-R124)

**Other Minor Improvements**

* Removed the "Coming soon" badge for Cashup in the quickstart guide provider list.

These changes ensure that the documentation accurately reflects the current state of SDK and provider support, streamlines installation for developers, and keeps download resources up to date.