### PR TITLE
add release note

### DIFF
--- a/sdk/c2c/android-sdk/index.mdx
+++ b/sdk/c2c/android-sdk/index.mdx
@@ -18,6 +18,9 @@ TerminalC2C is a singleton object that provides both synchronous (suspend) and a
 ## Version information
 
 <AccordionGroup>
+  <Accordion title="v1.1.3 — 26-Apr-2026">
+    What's new:
+    - Fixed casting issue on C2C request payload to improve compatibility and prevent runtime errors.
   <Accordion title="v1.1.1 — 23-Apr-2026">
     What's new:
     - Added Cashup provider support for Indonesian terminals

--- a/sdk/c2c/ios-sdk/index.mdx
+++ b/sdk/c2c/ios-sdk/index.mdx
@@ -18,6 +18,10 @@ This SDK uses a singleton pattern with the `TerminalC2C` object to communicate w
 ## Version information
 
 <AccordionGroup>
+  <Accordion title="v1.1.3 — 26-Apr-2026">
+    What's new:
+    - Fixed casting issue on C2C request payload to improve compatibility and prevent runtime errors.
+  </Accordion>
   <Accordion title="v1.1.1 — 23-Apr-2026">
     What's new:
     - Added Cashup provider support for Indonesian terminals

--- a/sdk/h2h/android-sdk/index.mdx
+++ b/sdk/h2h/android-sdk/index.mdx
@@ -14,6 +14,11 @@ This SDK works alongside the Terminal API to provide complete in-person payment 
 ## Version information
 
 <AccordionGroup>
+
+  <Accordion title="v1.1.3 — 26-Apr-2026">
+    What's new:
+    - Fixed casting issue on C2C request payload to improve compatibility and prevent runtime errors.
+  </Accordion>
   <Accordion title="v1.1.1 — 23-Apr-2026">
     What's new:
     - Added Cashup provider support for Indonesian terminals
@@ -33,12 +38,12 @@ This SDK works alongside the Terminal API to provide complete in-person payment 
     - Added timeout configuration for card and QR transactions to auto-cancel and retry stalled requests
     - Added support to handle retry requests via <a href="/api-reference/payments-terminal-api/retry-terminal-payment-session">`/v1/terminal/sessions/{id}/retry`</a> endpoint
   </Accordion>
-  <Accordion title="v0.6.0 — 20-Nov-2025">
-    What's new:
-    - Added support for multiple concurrent device connections, enabling simultaneous transactions across different terminals
-    - [BRI] Fixed status value handling in void and cancel API responses for improved transaction status accuracy
-  </Accordion>
   <Accordion title="View all versions">
+    <Accordion title="v0.6.0 — 20-Nov-2025">
+      What's new:
+      - Added support for multiple concurrent device connections, enabling simultaneous transactions across different terminals
+      - [BRI] Fixed status value handling in void and cancel API responses for improved transaction status accuracy
+    </Accordion>
     <AccordionGroup>
       <Accordion title="v0.5.0 — 30-Oct-2025">
         What's new:

--- a/sdk/h2h/ios-sdk/index.mdx
+++ b/sdk/h2h/ios-sdk/index.mdx
@@ -14,6 +14,10 @@ This SDK works alongside the Terminal API to provide a complete in-person paymen
 ## Version information
 
 <AccordionGroup>
+  <Accordion title="v1.1.3 — 26-Apr-2026">
+    What's new:
+    - Fixed casting issue on C2C request payload to improve compatibility and prevent runtime errors.
+  </Accordion>
   <Accordion title="v1.1.1 — 23-Apr-2026">
     What's new:
     - Added Cashup provider support for Indonesian terminals
@@ -26,14 +30,14 @@ This SDK works alongside the Terminal API to provide a complete in-person paymen
     **Breaking Change**: Class name changed from `TerminalGateway` to `TerminalH2H`. Update your imports and references accordingly.
     </Warning>
   </Accordion>
-  <Accordion title="v0.7.0 — 5-Dec-2025">
-    What's new:
-    - Fixed NTT payment method value mapping to ensure correct provider selection
-    - Updated BRI payment flow to validate transaction data before executing terminal actions
-    - Added timeout configuration for card and QR transactions to auto-cancel and retry stalled requests
-    - Added support to handle retry requests via <a href="/api-reference/payments-terminal-api/retry-terminal-payment-session">`/v1/terminal/sessions/{id}/retry`</a> endpoint
-  </Accordion>
   <Accordion title="View all versions">
+    <Accordion title="v0.7.0 — 5-Dec-2025">
+      What's new:
+      - Fixed NTT payment method value mapping to ensure correct provider selection
+      - Updated BRI payment flow to validate transaction data before executing terminal actions
+      - Added timeout configuration for card and QR transactions to auto-cancel and retry stalled requests
+      - Added support to handle retry requests via <a href="/api-reference/payments-terminal-api/retry-terminal-payment-session">`/v1/terminal/sessions/{id}/retry`</a> endpoint
+    </Accordion>
     <AccordionGroup>
       <Accordion title="v0.6.0 — 20-Nov-2025">
         What's new:


### PR DESCRIPTION
This pull request updates the SDK documentation for both C2C and H2H Android/iOS SDKs to include the release notes for version 1.1.3. The main focus is on communicating a bug fix related to a casting issue in the C2C request payload, which improves compatibility and prevents runtime errors. Additionally, some accordion structures in the documentation were reorganized for clarity.

**SDK Documentation Updates:**

* Added release notes for version `v1.1.3` (dated 26-Apr-2026) to the following documentation files, highlighting a fix for a casting issue on the C2C request payload to improve compatibility and prevent runtime errors. [[1]](diffhunk://#diff-d6e8b144c02e3046e4690fc1d7a7f3b9d71b7bd75ba232812339bb026703289bR21-R23) [[2]](diffhunk://#diff-1da94036bb1e30feef58b5743b6843a704bb59eea0c232b53c78c08db4486c8cR21-R24) [[3]](diffhunk://#diff-9eaead37c639fc1d4eb084318ebe5895d40696ee04ed245eee68038390002892R17-R21) [[4]](diffhunk://#diff-4c437b55ab2e15178f2a651bf4b5128c3ecdf0649f07f6081183988e844be942R17-R20)

**Documentation Structure Improvements:**

* Reorganized the accordion structure in both `sdk/h2h/android-sdk/index.mdx` and `sdk/h2h/ios-sdk/index.mdx` by moving the "View all versions" section after the latest version notes for better readability. [[1]](diffhunk://#diff-9eaead37c639fc1d4eb084318ebe5895d40696ee04ed245eee68038390002892R41-L41) [[2]](diffhunk://#diff-4c437b55ab2e15178f2a651bf4b5128c3ecdf0649f07f6081183988e844be942R33-L36)