### PR TITLE
Update xen-bri-to-h2h.mdx

### DIFF
--- a/guides/migration/xen-bri-to-h2h.mdx
+++ b/guides/migration/xen-bri-to-h2h.mdx
@@ -83,7 +83,7 @@ The new architecture separates the concerns of direct terminal communication (ha
   ```
 
   <Note>
-  **Client Key:** Note that for the Terminal API (H2H), you will need an `API_KEY` from the Xendit In-Person Payment team, which is different from the `CLIENT_KEY` used in the SDK initialization. The `TerminalApp.initialize` still uses a `CLIENT_KEY`.
+  **Credentials:** For this integration, `API_KEY` and `CLIENT_KEY` refer to the same credential from the Xendit In-Person Payment team. Use the same key when calling the Terminal API (H2H) and when initializing `TerminalApp`.
   </Note>
 
   <Note>


### PR DESCRIPTION
This pull request updates the migration guide to clarify the usage of credentials when integrating with the Terminal API (H2H). The note now specifies that both `API_KEY` and `CLIENT_KEY` refer to the same credential, simplifying the integration process.

Documentation update:

* Clarified in `guides/migration/xen-bri-to-h2h.mdx` that `API_KEY` and `CLIENT_KEY` are the same credential for both Terminal API (H2H) and `TerminalApp` initialization.