### PR TITLE
Update openapi-spec-c2c.yaml

### DIFF
--- a/openapi-spec-c2c.yaml
+++ b/openapi-spec-c2c.yaml
@@ -442,8 +442,8 @@ paths:
     post:
       tags:
         - In-person payments C2C API
-      summary: Cancel Payment
-      description: Cancels an ongoing payment transaction.
+      summary: Void Payment
+      description: Voids a completed payment transaction.
       operationId: cancelPayment
       parameters:
         - name: provider


### PR DESCRIPTION
This pull request updates the OpenAPI specification to clarify the terminology and behavior of the payment cancellation endpoint. The most important change is:

**API Documentation Update:**

* Updated the `summary` and `description` for the `cancelPayment` endpoint in `openapi-spec-c2c.yaml` to use the term "Void Payment" and specify that it voids a completed payment transaction, instead of canceling an ongoing one.