### PR TITLE
Configuring App for Terminal Device

### DIFF
--- a/sdk/c2c/android-sdk/index.mdx
+++ b/sdk/c2c/android-sdk/index.mdx
@@ -408,7 +408,7 @@ You can also specify a device per request instead of setting a default device.
 ## Configuring App for Terminal Device
 
 <Tabs>
-<Tab title="Cashup">
+<Tab title="Cashup Indonesia">
 When running your application on a Terminal device, additional configuration is required to enable the terminal to communicate with the Cashup payment system. Follow these steps:
 
 <Steps>
@@ -465,6 +465,68 @@ When running your application on a Terminal device, additional configuration is 
   
   <Check>
   Your app is now configured to run on Cashup Terminal devices and can communicate with the Cashup payment system.
+  </Check>
+</Step>
+</Steps>
+</Tab>
+
+<Tab title="SHC Malaysia">
+When running your application on a Terminal device, additional configuration is required to enable the terminal to communicate with the SHC payment system. Follow these steps:
+
+<Steps>
+<Step title="Configure AndroidManifest.xml">
+  Add the SHC result activity to your `AndroidManifest.xml` file:
+  
+  ```xml AndroidManifest.xml
+  <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application>
+      <!-- Your other activities -->
+      
+      <!-- SHC Result Activity -->
+      <activity
+        android:exported="true"
+        android:name="co.xendit.terminal.shc.activity.ResultActivity" />
+    </application>
+  </manifest>
+  ```
+  
+  <Warning>
+  The `android:exported="true"` attribute is required to allow the SHC system to return results to your application.
+  </Warning>
+</Step>
+
+<Step title="Extend TerminalApplication">
+  Make your `Application` class extend `TerminalApplication` and configure the SHC provider launcher:
+  
+  ```kotlin Application.kt
+  import android.app.Application
+  import co.xendit.terminal.core.application.TerminalApplication
+  import co.xendit.terminal.shc.TerminalSHC
+  import co.xendit.terminal.shc.launcher.SHCAppLauncher
+  
+  class MyApplication : TerminalApplication() {
+    override fun onCreate() {
+      super.onCreate()
+      
+      // Configure SHC provider app launcher
+      TerminalSHC.providerAppLauncher = SHCAppLauncher(this)
+    }
+  }
+  ```
+  
+  <Info>
+  Don't forget to register your custom `Application` class in the `AndroidManifest.xml`:
+  
+  ```xml AndroidManifest.xml
+  <application
+    android:name=".MyApplication"
+    ...>
+  </application>
+  ```
+  </Info>
+  
+  <Check>
+  Your app is now configured to run on SHC Terminal devices and can communicate with the SHC payment system.
   </Check>
 </Step>
 </Steps>

--- a/sdk/c2c/android-sdk/index.mdx
+++ b/sdk/c2c/android-sdk/index.mdx
@@ -38,7 +38,7 @@ TerminalC2C is a singleton object that provides both synchronous (suspend) and a
       - Added SHC provider support for Malaysian terminals
       - Added multiple-provider support enabling apps to handle different terminal types simultaneously
       - Enhanced TerminalDevice configuration with provider-specific methods
-      - Improved terminal selection for apps managing multiple EDC devices
+      - Improved terminal selection for apps managing multiple Terminal devices
     </Accordion>
   </Accordion>
 </AccordionGroup>
@@ -350,8 +350,8 @@ Provider-specific methods require the corresponding dependency:
 </Note>
 </Tab>
 
-<Tab title="Multiple EDC Devices">
-For apps handling multiple EDC devices, configure each terminal and specify per transaction:
+<Tab title="Multiple Terminal Devices">
+For apps handling multiple Terminal devices, configure each terminal and specify per transaction:
 
 ```kotlin
 import co.xendit.terminal.c2c.TerminalC2C
@@ -405,6 +405,71 @@ This approach allows dynamic terminal selection based on business logic, locatio
 You can also specify a device per request instead of setting a default device.
 </Tip>
 
+## Configuring App for Terminal Device
+
+<Tabs>
+<Tab title="Cashup">
+When running your application on a Terminal device, additional configuration is required to enable the terminal to communicate with the Cashup payment system. Follow these steps:
+
+<Steps>
+<Step title="Configure AndroidManifest.xml">
+  Add the Cashup result activity to your `AndroidManifest.xml` file:
+  
+  ```xml AndroidManifest.xml
+  <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application>
+      <!-- Your other activities -->
+      
+      <!-- Cashup Result Activity -->
+      <activity
+        android:exported="true"
+        android:name="co.xendit.terminal.cashup.activity.ResultActivity" />
+    </application>
+  </manifest>
+  ```
+  
+  <Warning>
+  The `android:exported="true"` attribute is required to allow the Cashup system to return results to your application.
+  </Warning>
+</Step>
+
+<Step title="Extend TerminalApplication">
+  Make your `Application` class extend `TerminalApplication` and configure the Cashup provider launcher:
+  
+  ```kotlin Application.kt
+  import android.app.Application
+  import co.xendit.terminal.core.application.TerminalApplication
+  import co.xendit.terminal.cashup.TerminalCashup
+  import co.xendit.terminal.cashup.launcher.CashupAppLauncher
+  
+  class MyApplication : TerminalApplication() {
+    override fun onCreate() {
+      super.onCreate()
+      
+      // Configure Cashup provider app launcher
+      TerminalCashup.providerAppLauncher = CashupAppLauncher(this)
+    }
+  }
+  ```
+  
+  <Info>
+  Don't forget to register your custom `Application` class in the `AndroidManifest.xml`:
+  
+  ```xml AndroidManifest.xml
+  <application
+    android:name=".MyApplication"
+    ...>
+  </application>
+  ```
+  </Info>
+  
+  <Check>
+  Your app is now configured to run on Cashup Terminal devices and can communicate with the Cashup payment system.
+  </Check>
+</Step>
+</Steps>
+</Tab>
+</Tabs>
 
 ## Supported Payment Methods by Provider
 


### PR DESCRIPTION
This pull request updates the Android SDK documentation to clarify terminology and add detailed setup instructions for integrating with Cashup and SHC terminal devices. The changes improve guidance for configuring applications to communicate with different terminal providers and ensure correct integration steps are followed.

**Documentation improvements for terminal device integration:**

- Added comprehensive configuration guides for integrating with Cashup Indonesia and SHC Malaysia terminal devices, including necessary changes to `AndroidManifest.xml` and `Application` class setup. These guides provide step-by-step instructions to ensure correct communication with each payment provider.

**Terminology and clarity enhancements:**

- Updated terminology throughout the documentation to use "Terminal devices" instead of "EDC devices" for greater accuracy and consistency, including section titles and instructional text. [[1]](diffhunk://#diff-d6e8b144c02e3046e4690fc1d7a7f3b9d71b7bd75ba232812339bb026703289bL41-R41) [[2]](diffhunk://#diff-d6e8b144c02e3046e4690fc1d7a7f3b9d71b7bd75ba232812339bb026703289bL353-R354)