### PR TITLE
Add missing tab

### DIFF
--- a/sdk/c2c/android-sdk/index.mdx
+++ b/sdk/c2c/android-sdk/index.mdx
@@ -592,6 +592,20 @@ NTT terminals provide comprehensive payment method support for the Thai market, 
 </Note>
 
 </Tab>
+
+<Tab title="SHC Terminals">
+
+When using `co.xendit.terminal:my-shc-android` dependency for Malaysia market:
+
+| Payment Method | Description | Code Example |
+|---|---|---|
+| **Card** | Credit/debit card transactions | `SHCPaymentMethod.card` |
+
+<Note>
+SHC terminals support card payment methods tailored for the Malaysian market.
+</Note>
+
+</Tab>
 </Tabs>
 
 <Warning>


### PR DESCRIPTION
This pull request adds documentation for SHC terminals to the Android SDK guide, specifically targeting the Malaysian market. The new section outlines supported payment methods for SHC terminals and provides relevant code examples.

**Documentation updates for terminal support:**

* Added a new tab for "SHC Terminals" in the Android SDK documentation, including instructions for using the `co.xendit.terminal:my-shc-android` dependency for the Malaysian market, and documented card payment support with code examples.