### PR TITLE
fix naming

### DIFF
--- a/components/H2HProviderSnippetInit.jsx
+++ b/components/H2HProviderSnippetInit.jsx
@@ -117,7 +117,7 @@ class App : Application() {
     super.onCreate()
 
     TerminalApp.initialize(
-      application = this,
+      context = this,
       clientKey = CLIENT_KEY,
       mode = TerminalMode.LIVE // or TerminalMode.INTEGRATION
     )

--- a/sdk/h2h/android-sdk/index.mdx
+++ b/sdk/h2h/android-sdk/index.mdx
@@ -213,7 +213,7 @@ class MyApp : Application() {
     super.onCreate()
 
     TerminalApp.initialize(
-      application = this,
+      context = this,
       clientKey = TEST_CLIENT_KEY,
       mode = TerminalMode.INTEGRATION
     )

--- a/snippets/h2h-sdk-quickstart-content.mdx
+++ b/snippets/h2h-sdk-quickstart-content.mdx
@@ -75,7 +75,7 @@ class App : Application() {
     super.onCreate()
 
     TerminalApp.initialize(
-      application = this,
+      context = this,
       clientKey = CLIENT_KEY,
       mode = TerminalMode.LIVE // or TerminalMode.INTEGRATION
     )


### PR DESCRIPTION
This pull request updates the initialization of the `TerminalApp` in several documentation and code snippet files to use the `context` parameter instead of `application`. This change ensures consistency with the updated SDK interface and prevents potential confusion for developers integrating the SDK.

**SDK initialization parameter update:**

* Changed the parameter from `application` to `context` in the `TerminalApp.initialize` call within the following files:
  - `components/H2HProviderSnippetInit.jsx`
  - `sdk/h2h/android-sdk/index.mdx`
  - `snippets/h2h-sdk-quickstart-content.mdx`